### PR TITLE
fix:js file not found in view template

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -65,7 +65,7 @@ app.use(morgan.middleware(C.morganFormat));
 
 var IndexRouter = require('./routes');
 app.use(mount('/', IndexRouter));
-app.use(koaStatic('./public/'));
+app.use(koaStatic(path.join(__dirname,'./public/')));
 
 startServer(app, +argv.port);
 


### PR DESCRIPTION
koa.static should use absolute paths

> // or use absolute paths
> app.use(serve(__dirname + '/test/fixtures'));
