### PR TITLE
Fix bootcss.com being unresponsive and direct traffic to cdnjs.

### DIFF
--- a/lib/views/files.html
+++ b/lib/views/files.html
@@ -6,10 +6,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>File Manager</title>
 
-  <link href="//cdn.bootcss.com/bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet">
-  <script src="//cdn.bootcss.com/jquery/2.1.4/jquery.min.js"></script>
-  <script src="//cdn.bootcss.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
-  <script src="//cdn.bootcss.com/angular.js/1.4.5/angular.min.js"></script>
+  <link href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet">
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.5/js/bootstrap.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.4.5/angular.min.js"></script>
   <script src="js/angular-file.js"></script>
   <script src="js/app.js"></script>
 


### PR DESCRIPTION
We are having lots of trouble here with the bootcss.com being slow and sometimes you can't reach it at all.  We found we could direct the CDN to cdnjs and its very fast.